### PR TITLE
Make Lambda runnable on AWS.

### DIFF
--- a/crossword-pdf-uploader/project/Build.scala
+++ b/crossword-pdf-uploader/project/Build.scala
@@ -11,7 +11,7 @@ object CrosswordUploaderBuild extends Build {
     scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked")
   )
 
-  val root = Project("crossword", file("."))
+  val root = Project("crossword-pdf-uploader", file("."))
     .settings(
 
       libraryDependencies ++= Seq(

--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/DevMain.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/DevMain.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration.Duration
  */
 object DevMain extends App {
 
-  val fakeScheduledEvent = new util.HashMap[String, String]()
+  val fakeScheduledEvent = new util.HashMap[String, Object]()
 
   val start = System.nanoTime()
   new Lambda().handleRequest(fakeScheduledEvent, null)

--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
@@ -8,12 +8,12 @@ import com.squareup.okhttp._
 import org.apache.http.HttpStatus
 
 class Lambda
-    extends RequestHandler[JMap[String, String], Unit]
+    extends RequestHandler[JMap[String, Object], Unit]
     with CrosswordUploader
     with CrosswordStore
     with PublicPdfStore {
 
-  override def handleRequest(event: JMap[String, String], context: Context): Unit = {
+  override def handleRequest(event: JMap[String, Object], context: Context): Unit = {
     implicit val config = new Config(context)
 
     println("The uploading of crossword pdf files has started.")

--- a/crossword-xml-uploader/project/Build.scala
+++ b/crossword-xml-uploader/project/Build.scala
@@ -11,7 +11,7 @@ object CrosswordUploaderBuild extends Build {
     scalacOptions ++= Seq("-deprecation", "-feature", "-unchecked")
   )
 
-  val root = Project("crossword", file("."))
+  val root = Project("crossword-xml-uploader", file("."))
     .settings(
 
       libraryDependencies ++= Seq(

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/DevMain.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/DevMain.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration.Duration
  */
 object DevMain extends App {
 
-  val fakeScheduledEvent = new util.HashMap[String, String]()
+  val fakeScheduledEvent = new util.HashMap[String, Object]()
 
   val start = System.nanoTime()
   new Lambda().handleRequest(fakeScheduledEvent, null)

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/Lambda.scala
@@ -5,11 +5,11 @@ import com.amazonaws.services.lambda.runtime.{ RequestHandler, Context }
 import com.squareup.okhttp._
 
 class Lambda
-    extends RequestHandler[JMap[String, String], Unit]
+    extends RequestHandler[JMap[String, Object], Unit]
     with CrosswordUploader
     with CrosswordStore {
 
-  override def handleRequest(event: JMap[String, String], context: Context): Unit = {
+  override def handleRequest(event: JMap[String, Object], context: Context): Unit = {
 
     implicit val config = new Config(context)
 


### PR DESCRIPTION
AWS does not provide a scheduled event model in their SDK. We can get around this by using a map and loosening the value type.
Also, we do not care about the contents of the event.