### PR TITLE
Archive files after upload

### DIFF
--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Config.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Config.scala
@@ -17,7 +17,6 @@ class Config(val context: Context) extends S3Provider {
   val crosswordPdfPublicBucketName = s"crosswords-pdf-public-${stage.toLowerCase}"
   val crosswordPdfPublicFileLocation = if (isProd) s"https://crosswords-static.guim.co.uk" else s"https://s3-eu-west-1.amazonaws.com/$crosswordPdfPublicBucketName"
 
-
   private def loadConfig() = {
     val configFileKey = s"crossword-pdf-uploader/$stage/config.properties"
     val configInputStream = s3Client.getObject("crossword-uploader-config", configFileKey).getObjectContent

--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Config.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Config.scala
@@ -9,7 +9,7 @@ import scala.util.Try
 
 class Config(val context: Context) extends S3Provider {
 
-  private val isProd = Try(context.getFunctionName.toLowerCase.contains("-prod")).getOrElse(false)
+  val isProd = Try(context.getFunctionName.toLowerCase.contains("-prod")).getOrElse(false)
   private val stage = if (isProd) "PROD" else "CODE"
   private val config = loadConfig()
 

--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
@@ -29,7 +29,9 @@ class Lambda
   }
 
   private def handleResponse(response: Response, crosswordPdfFile: CrosswordPdfFile) = {
+    println(s"Microapp response: '${response.message}' with status code: ${response.code}")
     if (response.isSuccessful) {
+      archiveProcessedPdfFiles(crosswordPdfFile.awsKey)
       println(s"Successfully uploaded crossword ${crosswordPdfFile.awsKey}")
     } else if (response.code() == HttpStatus.SC_NOT_FOUND) {
       println(s"Looks like the crossword microapp could not find the relevant crossword for ${crosswordPdfFile.awsKey}. " +

--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
@@ -28,10 +28,10 @@ class Lambda
     println("The uploading of crossword pdf files has finished.")
   }
 
-  private def handleResponse(response: Response, crosswordPdfFile: CrosswordPdfFile) = {
+  private def handleResponse(response: Response, crosswordPdfFile: CrosswordPdfFile)(implicit config: Config) = {
     println(s"Microapp response: '${response.message}' with status code: ${response.code}")
     if (response.isSuccessful) {
-      archiveProcessedPdfFiles(crosswordPdfFile.awsKey)
+      if (config.isProd) archiveProcessedPdfFiles(crosswordPdfFile.awsKey)
       println(s"Successfully uploaded crossword ${crosswordPdfFile.awsKey}")
     } else if (response.code() == HttpStatus.SC_NOT_FOUND) {
       println(s"Looks like the crossword microapp could not find the relevant crossword for ${crosswordPdfFile.awsKey}. " +

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/Config.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/Config.scala
@@ -8,7 +8,7 @@ import scala.util.Try
 
 class Config(val context: Context) {
 
-  private val isProd = Try(context.getFunctionName.toLowerCase.contains("-prod")).getOrElse(false)
+  val isProd = Try(context.getFunctionName.toLowerCase.contains("-prod")).getOrElse(false)
   private val stage = if (isProd) "PROD" else "CODE"
   private val config = loadConfig()
 

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/ComposerCrosswordIntegration.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/ComposerCrosswordIntegration.scala
@@ -27,7 +27,7 @@ trait ComposerCrosswordIntegration extends Kinesis with CrosswordStore {
       println(s"Crossword page creation request to Composer for crossword ${crosswordXmlFile.key} failed.")
     } else {
       println(s"Crossword page creation request sent to Composer for crossword ${crosswordXmlFile.key}.")
-      archiveCrosswordXMLFile(crosswordXmlFile.key)
+      if (config.isProd) archiveCrosswordXMLFile(crosswordXmlFile.key)
     }
   }
 

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/ComposerCrosswordIntegration.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/ComposerCrosswordIntegration.scala
@@ -10,7 +10,7 @@ import com.amazonaws.services.kinesis.model.{ PutRecordsRequestEntry, PutRecords
 
 import scala.xml._
 
-trait ComposerCrosswordIntegration extends Kinesis {
+trait ComposerCrosswordIntegration extends Kinesis with CrosswordStore {
 
   def createPage(crosswordXmlFile: CrosswordXmlFile, crosswordXmlToCreatePage: Elem)(implicit config: Config): Unit = {
 
@@ -27,6 +27,7 @@ trait ComposerCrosswordIntegration extends Kinesis {
       println(s"Crossword page creation request to Composer for crossword ${crosswordXmlFile.key} failed.")
     } else {
       println(s"Crossword page creation request sent to Composer for crossword ${crosswordXmlFile.key}.")
+      archiveCrosswordXMLFile(crosswordXmlFile.key)
     }
   }
 

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
@@ -30,4 +30,11 @@ trait CrosswordStore {
     out.toByteArray
   }
 
+  def archiveCrosswordXMLFile(awsKey: String): Unit = {
+    val archiveBucketName = "crossword-processed-files"
+    println(s"Moving $awsKey to bucket $archiveBucketName")
+    s3Client.copyObject(crosswordsBucketName, awsKey, archiveBucketName, awsKey)
+    s3Client.deleteObject(crosswordsBucketName, awsKey)
+  }
+
 }

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/services/Kinesis.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/services/Kinesis.scala
@@ -1,6 +1,5 @@
 package com.gu.crossword.services
 
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.{ Region, Regions }
 import com.amazonaws.services.kinesis.AmazonKinesisAsyncClient
 import com.gu.crossword.Config
@@ -8,7 +7,7 @@ import com.gu.crossword.Config
 trait Kinesis {
 
   lazy val kinesisClient: AmazonKinesisAsyncClient = {
-    val kinesisClient = new AmazonKinesisAsyncClient(new ProfileCredentialsProvider("composer"))
+    val kinesisClient = new AmazonKinesisAsyncClient()
     kinesisClient.setRegion(Region.getRegion(Regions.EU_WEST_1))
     kinesisClient
 

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/services/Kinesis.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/services/Kinesis.scala
@@ -1,5 +1,6 @@
 package com.gu.crossword.services
 
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.{ Region, Regions }
 import com.amazonaws.services.kinesis.AmazonKinesisAsyncClient
 import com.gu.crossword.Config
@@ -7,7 +8,7 @@ import com.gu.crossword.Config
 trait Kinesis {
 
   lazy val kinesisClient: AmazonKinesisAsyncClient = {
-    val kinesisClient = new AmazonKinesisAsyncClient()
+    val kinesisClient = new AmazonKinesisAsyncClient(new ProfileCredentialsProvider("composer"))
     kinesisClient.setRegion(Region.getRegion(Regions.EU_WEST_1))
     kinesisClient
 

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/services/S3.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/services/S3.scala
@@ -1,7 +1,10 @@
 package com.gu.crossword.services
 
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.services.s3.AmazonS3Client
 
 object S3 {
+  // you might need to pass in 'new ProfileCredentialsProvider("composer)' here
   lazy val s3Client: AmazonS3Client = new AmazonS3Client()
+
 }


### PR DESCRIPTION
After a PDF/XML file has been successfully sent to the microapp/composer, copy all versions of it to the crossword-processed-files bucket, then delete it from the crossword-files-for-processing bucket

This should keep the 'files for processing' bucket clean and reduce the chances of something being republished on the wrong day. 