### PR TITLE
Support British Summer Time

### DIFF
--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/XmlProcessor.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/XmlProcessor.scala
@@ -2,10 +2,21 @@ package com.gu.crossword.crosswords
 
 import java.util.Locale
 import scala.xml._
-import org.joda.time.format.{ DateTimeFormat }
+import org.joda.time.format.{ DateTimeFormat, ISODateTimeFormat }
 import org.joda.time.{ DateTimeZone, LocalDateTime }
 
-trait XmlProcessor {
+trait DateLogic {
+
+  def transformDate(dateString: String): String = {
+    val inputFormat = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm")
+    val outputFormat = ISODateTimeFormat.dateTime()
+    val isoFormattedOutput = LocalDateTime.parse(dateString, inputFormat).toDateTime(DateTimeZone.forID("Europe/London")).toString(outputFormat)
+    isoFormattedOutput.replaceAllLiterally("Z", "+00:00")
+  }
+
+}
+
+trait XmlProcessor extends DateLogic {
 
   def process(crosswordXml: Elem): Elem = {
 
@@ -42,10 +53,8 @@ trait XmlProcessor {
   }
 
   private def getDate(elementName: String)(implicit crosswordXml: Elem): String = {
-    val inputFormat = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm")
-    val outputFormat = DateTimeFormat.forPattern("yyyy-MM-dd'T00:00:00.000+00:00").withLocale(Locale.UK).withZone(DateTimeZone.forID("Europe/London"))
     val dateString = (crosswordXml \\ elementName).text
-    LocalDateTime.parse(dateString, inputFormat).toString(outputFormat)
+    transformDate(dateString)
   }
 
   private def getExternalReferences(implicit crosswordXml: Elem): Seq[(String, String)] = {

--- a/crossword-xml-uploader/src/test/scala/com/gu/crossword/crosswords/DateLogicTest.scala
+++ b/crossword-xml-uploader/src/test/scala/com/gu/crossword/crosswords/DateLogicTest.scala
@@ -1,0 +1,18 @@
+package com.gu.crossword.crosswords
+
+import org.scalatest.{ FlatSpec, Matchers }
+
+import scala.io.Source
+import scala.xml.XML
+
+class DateLogicTest extends FlatSpec with Matchers with DateLogic {
+
+  it should "transform a date during British winter time" in {
+    transformDate("20.03.2016 00:00") should be("2016-03-20T00:00:00.000+00:00")
+  }
+
+  it should "transform a date during British summer time" in {
+    transformDate("30.03.2016 00:00") should be("2016-03-30T00:00:00.000+01:00")
+  }
+
+}


### PR DESCRIPTION
This sets the time zone offset correctly in the `issue-date` and `web-publication-date` attrs in the XML that is published to Kinesis.

This should cause crossword pages to be scheduled for publication at midnight rather than 1am.

@philmcmahon