### PR TITLE
Correction in datetime handling for crossword web publication date

### DIFF
--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/XmlProcessor.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/XmlProcessor.scala
@@ -3,14 +3,14 @@ package com.gu.crossword.crosswords
 import java.util.Locale
 import scala.xml._
 import org.joda.time.format.{ DateTimeFormat, ISODateTimeFormat }
-import org.joda.time.{ DateTimeZone, LocalDateTime }
+import org.joda.time.{ DateTimeZone, LocalDateTime, DateTime }
 
 trait DateLogic {
 
   def transformDate(dateString: String): String = {
-    val inputFormat = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm")
-    val outputFormat = ISODateTimeFormat.dateTime()
-    val isoFormattedOutput = LocalDateTime.parse(dateString, inputFormat).toDateTime(DateTimeZone.forID("Europe/London")).toString(outputFormat)
+    val inputFormat = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm").withZone(DateTimeZone.forID("Europe/London"))
+    val outputFormat = ISODateTimeFormat.dateTime().withZone(DateTimeZone.forID("UTC"))
+    val isoFormattedOutput = DateTime.parse(dateString, inputFormat).toString(outputFormat)
     isoFormattedOutput.replaceAllLiterally("Z", "+00:00")
   }
 

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/XmlProcessor.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/XmlProcessor.scala
@@ -9,9 +9,8 @@ trait DateLogic {
 
   def transformDate(dateString: String): String = {
     val inputFormat = DateTimeFormat.forPattern("dd.MM.yyyy HH:mm").withZone(DateTimeZone.forID("Europe/London"))
-    val outputFormat = ISODateTimeFormat.dateTime().withZone(DateTimeZone.forID("UTC"))
-    val isoFormattedOutput = DateTime.parse(dateString, inputFormat).toString(outputFormat)
-    isoFormattedOutput.replaceAllLiterally("Z", "+00:00")
+    val outputFormat = DateTimeFormat.forPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").withZone(DateTimeZone.forID("UTC"))
+    DateTime.parse(dateString, inputFormat).toString(outputFormat)
   }
 
 }

--- a/crossword-xml-uploader/src/test/scala/com/gu/crossword/crosswords/DateLogicTest.scala
+++ b/crossword-xml-uploader/src/test/scala/com/gu/crossword/crosswords/DateLogicTest.scala
@@ -12,7 +12,7 @@ class DateLogicTest extends FlatSpec with Matchers with DateLogic {
   }
 
   it should "transform a date during British summer time" in {
-    transformDate("30.03.2016 00:00") should be("2016-03-30T00:00:00.000+01:00")
+    transformDate("30.03.2016 00:00") should be("2016-03-29T23:00:00.000+00:00")
   }
 
 }


### PR DESCRIPTION
This change makes the publishing datetime for crosswords
appear in UTC. In particular during summer time, when the
UK is at BST (UTC+1) the datetime appears as 2016-03-29T23:00:00.000+00:00

This fixes an existing issue by which crosswords are being published one hour late
during summer.