### PR TITLE
Fix BST crossword pdf publishing

### DIFF
--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/models/Crossword.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/models/Crossword.scala
@@ -1,12 +1,12 @@
 package com.gu.crossword.models
 
-import org.joda.time.{ DateTimeConstants, DateTime, LocalDate }
-import scala.util.{ Success, Try }
+import org.joda.time.{DateTime, DateTimeConstants, DateTimeZone, LocalDate}
+import scala.util.{Success, Try}
 
 case class CrosswordPdfFile(awsKey: String, filename: CrosswordPdfFileName, file: Array[Byte])
 
 case class CrosswordPdfFileName(year: String, month: String, day: String, `type`: String, fileName: String) {
-  def getPublicationDate: DateTime = new LocalDate(year.toInt, month.toInt, day.toInt).toDateTimeAtStartOfDay
+  def getPublicationDate: DateTime = new LocalDate(year.toInt, month.toInt, day.toInt).toDateTimeAtStartOfDay(DateTimeZone.forID("Europe/London"))
 }
 
 object CrosswordPdfFileName {


### PR DESCRIPTION
To work out whether or not to make a pdf public, the app takes the date contained in the name of the pdf file, converts it into a LocalDate, then immediately converts that into a DateTime using the toDateTimeAtStartOfDay function. This function uses UTC by default, resulting in crossword PDFs getting published at 00:00 UTC, which is 01:00 BST = too late! 

This fixes that problem by specifying the time zone as Europe/London