### PR TITLE
Safer string parsing

### DIFF
--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/stores/CrosswordStore.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/stores/CrosswordStore.scala
@@ -34,7 +34,9 @@ trait CrosswordStore extends S3Provider {
     /* Sort crosswords by name */
     val groupedSummaries = getCrosswordPdfObjectSummaries.groupBy(os => {
       val nameParts = os.getKey.split("\\.").toList
-      List(nameParts(0), nameParts(1), nameParts(2)).mkString(".")
+      if (nameParts.length >= 3) {
+        List(nameParts(0), nameParts(1), nameParts(2)).mkString(".")
+      } else os.getKey
     })
 
     /* Remove oldest version of each crossword if multiple versions */


### PR DESCRIPTION
We had an issue where someone uploaded a PDF to the source bucket which had fewer than 2 `.` characters in the name. What's quite amazing is that this is the first time this has happened in THREE YEARS of this system being up. This change stops such occurrences from causing IndexOutOfBounds exceptions.