### PR TITLE
Log response from crossword microapp

### DIFF
--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordUploader.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordUploader.scala
@@ -19,7 +19,7 @@ trait CrosswordUploader extends ComposerCrosswordIntegration with XmlProcessor {
       createPage(crosswordXmlFile, crosswordXmlToCreatePage)
     } else
       println(s"Crossword upload failed for crossword: ${crosswordXmlFile.key}")
-
+      println(s"Returned error is $responseBody")
   }
 
   private def buildRequest(crosswordXmlFile: CrosswordXmlFile)(implicit config: Config) = {

--- a/crossword-xml-uploader/update-lambda.sh
+++ b/crossword-xml-uploader/update-lambda.sh
@@ -12,9 +12,16 @@ my_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
 sbt assembly
 
-jar_file=$(echo $my_dir/target/scala-2.11/crossword-xml-uploader-assembly*.jar)
+jar_file=$(ls $my_dir/target/scala-2.11/crossword-xml-uploader-assembly*.jar)
+jar_file_base=$(basename $jar_file)
+
+aws s3 cp \
+  --profile composer \
+  $jar_file \
+  s3://crossword-dist/crosswords/$STAGE/crossword-xml-uploader-lambda/$jar_file_base
 
 aws lambda update-function-code \
   --function-name crossword-xml-uploader-$STAGE \
   --profile composer \
-  --zip-file fileb://$jar_file
+  --s3-bucket crossword-dist \
+  --s3-key crosswords/$STAGE/crossword-xml-uploader-lambda/$jar_file_base


### PR DESCRIPTION
## What does this change?
Logs the response from the microapp in the event of failure to upload.
This exposes any error checking from the microapp, enabling us to more quickly diagnose duff crossword files.

## How can we measure success?
Log lines in cloudwatch showing error messages.