### PR TITLE
Separate input buckets for code and prod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 
 target/
 logs/
+
+**/*iml

--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/models/Crossword.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/models/Crossword.scala
@@ -1,7 +1,7 @@
 package com.gu.crossword.models
 
-import org.joda.time.{DateTime, DateTimeConstants, DateTimeZone, LocalDate}
-import scala.util.{Success, Try}
+import org.joda.time.{ DateTime, DateTimeConstants, DateTimeZone, LocalDate }
+import scala.util.{ Success, Try }
 
 case class CrosswordPdfFile(awsKey: String, filename: CrosswordPdfFileName, file: Array[Byte])
 

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/Config.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/Config.scala
@@ -15,6 +15,12 @@ class Config(val context: Context) {
   val crosswordMicroAppUrl = Option(config.getProperty("crosswordmicroapp.url")) getOrElse sys.error("'crosswordmicroapp.url' property missing.")
   val composerCrosswordIntegrationStreamName = Option(config.getProperty("composerCrosswordIntegration.streamName")) getOrElse sys.error("'composerCrosswordIntegration.streamName' property missing")
 
+  val crosswordsBucketName: String =
+    if (isProd)
+      "crossword-files-for-processing"
+    else
+      "crossword-files-for-processing-code"
+
   private def loadConfig() = {
     val configFileKey = s"crossword-xml-uploader/$stage/config.properties"
     val configInputStream = s3Client.getObject("crossword-uploader-config", configFileKey).getObjectContent

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/Lambda.scala
@@ -16,7 +16,7 @@ class Lambda
     println("The uploading of crossword xml files has started.")
 
     for {
-      crosswordXmlFile <- getCrosswordXmlFiles
+      crosswordXmlFile <- getCrosswordXmlFiles(config)
     } yield {
       uploadCrossword(crosswordXmlFile)
     }

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/ComposerCrosswordIntegration.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/ComposerCrosswordIntegration.scala
@@ -2,7 +2,6 @@ package com.gu.crossword.crosswords
 
 import java.nio.ByteBuffer
 
-import com.amazonaws.handlers.AsyncHandler
 import com.gu.crossword.Config
 import com.gu.crossword.crosswords.models.CrosswordXmlFile
 import com.gu.crossword.services.Kinesis
@@ -27,7 +26,7 @@ trait ComposerCrosswordIntegration extends Kinesis with CrosswordStore {
       println(s"Crossword page creation request to Composer for crossword ${crosswordXmlFile.key} failed.")
     } else {
       println(s"Crossword page creation request sent to Composer for crossword ${crosswordXmlFile.key}.")
-      if (config.isProd) archiveCrosswordXMLFile(crosswordXmlFile.key)
+      if (config.isProd) archiveCrosswordXMLFile(config, crosswordXmlFile.key)
     }
   }
 

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordUploader.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordUploader.scala
@@ -19,7 +19,7 @@ trait CrosswordUploader extends ComposerCrosswordIntegration with XmlProcessor {
       createPage(crosswordXmlFile, crosswordXmlToCreatePage)
     } else
       println(s"Crossword upload failed for crossword: ${crosswordXmlFile.key}")
-
+      println(s"Returned error is $responseBody")
   }
 
   private def buildRequest(crosswordXmlFile: CrosswordXmlFile)(implicit config: Config) = {


### PR DESCRIPTION
## What does this change?
Present version uses the same input bucket for both code and prod.

## How can we measure success?
Code triggers off a separate bucket.
