### PR TITLE
Fix confusing log message

### DIFF
--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordUploader.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordUploader.scala
@@ -17,9 +17,10 @@ trait CrosswordUploader extends ComposerCrosswordIntegration with XmlProcessor {
       val crosswordXmlToCreatePage = process(XML.loadString(responseBody))
       println(s"creating page for crossword ${crosswordXmlFile.key} in flex.")
       createPage(crosswordXmlFile, crosswordXmlToCreatePage)
-    } else
+    } else {
       println(s"Crossword upload failed for crossword: ${crosswordXmlFile.key}")
       println(s"Returned error is $responseBody")
+    }
   }
 
   private def buildRequest(crosswordXmlFile: CrosswordXmlFile)(implicit config: Config) = {


### PR DESCRIPTION
depends on #26 

## What does this change?

I got very confused when testing, as the logged message was "Returned error response is [successful XML response]"

## How can we measure success?

Developers (ie. me) can test without spending 20 minutes trying to find the error in a successful response... 😅
