### PR TITLE
Archive failed crossword files into a different S3 bucket

### DIFF
--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
@@ -36,10 +36,9 @@ class Lambda
     } else if (response.code() == HttpStatus.SC_NOT_FOUND) {
       println(s"Looks like the crossword microapp could not find the relevant crossword for ${crosswordPdfFile.awsKey}. " +
         s"Are you sure its counterpart xml file has been uploaded first?")
-      archiveFailedPdfFiles(crosswordPdfFile.awsKey)
     } else {
       println(s"Upload of crossword PDF location for ${crosswordPdfFile.awsKey} failed.")
-      archiveFailedPdfFiles(crosswordPdfFile.awsKey)
+      if (config.isProd) archiveFailedPdfFiles(crosswordPdfFile.awsKey)
     }
   }
 

--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
@@ -36,7 +36,11 @@ class Lambda
     } else if (response.code() == HttpStatus.SC_NOT_FOUND) {
       println(s"Looks like the crossword microapp could not find the relevant crossword for ${crosswordPdfFile.awsKey}. " +
         s"Are you sure its counterpart xml file has been uploaded first?")
-    } else println(s"Upload of crossword PDF location for ${crosswordPdfFile.awsKey} failed.")
+      archiveFailedPdfFiles(crosswordPdfFile.awsKey)
+    } else {
+      println(s"Upload of crossword PDF location for ${crosswordPdfFile.awsKey} failed.")
+      archiveFailedPdfFiles(crosswordPdfFile.awsKey)
+    }
   }
 
 }

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/ComposerCrosswordIntegration.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/ComposerCrosswordIntegration.scala
@@ -24,6 +24,7 @@ trait ComposerCrosswordIntegration extends Kinesis with CrosswordStore {
     val putRecordsResult: PutRecordsResult = kinesisClient.putRecords(request)
     if (putRecordsResult.getFailedRecordCount > 0) {
       println(s"Crossword page creation request to Composer for crossword ${crosswordXmlFile.key} failed.")
+      archiveFailedCrosswordXMLFile(config, crosswordXmlFile.key)
     } else {
       println(s"Crossword page creation request sent to Composer for crossword ${crosswordXmlFile.key}.")
       if (config.isProd) archiveCrosswordXMLFile(config, crosswordXmlFile.key)

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
@@ -40,4 +40,9 @@ trait CrosswordStore {
     s3Client.deleteObject(config.crosswordsBucketName, awsKey)
   }
 
+  def archiveFailedCrosswordXMLFile(config: Config, awsKey: String): Unit = {
+    val processingFailedBucketName = "crossword-failed-files"
+    s3Client.copyObject(config.crosswordsBucketName, awsKey, processingFailedBucketName, awsKey)
+    s3Client.deleteObject(config.crosswordsBucketName, awsKey)
+  }
 }

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
@@ -43,6 +43,8 @@ trait CrosswordStore {
   def archiveFailedCrosswordXMLFile(config: Config, awsKey: String): Unit = {
     val processingFailedBucketName = "crossword-failed-files"
     s3Client.copyObject(config.crosswordsBucketName, awsKey, processingFailedBucketName, awsKey)
-    s3Client.deleteObject(config.crosswordsBucketName, awsKey)
+    if(s3Client.doesObjectExist(processingFailedBucketName, awsKey)) {
+      s3Client.deleteObject(config.crosswordsBucketName, awsKey)
+    }
   }
 }

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordUploader.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordUploader.scala
@@ -20,6 +20,7 @@ trait CrosswordUploader extends ComposerCrosswordIntegration with XmlProcessor {
     } else {
       println(s"Crossword upload failed for crossword: ${crosswordXmlFile.key}")
       println(s"Returned error is $responseBody")
+      archiveFailedCrosswordXMLFile(config, crosswordXmlFile.key)
     }
   }
 


### PR DESCRIPTION
## What does this change?
Currently, failed files persist in the processing bucket (such as an invalid XML file). This means every time the processing lambda runs (triggered whenever a new file appears in the bucket), it tries to re-processes _all_ the failed files as well as the new file. The impact is the Lambda logs and the Google app engine logs for the crossword microapp are polluted with lots of failures every time a file is processed, making debugging tricky and confusing. It will also be costing us more in compute time.

This pr proposes moving files that have failed to process into a separate failed bucket to allow for debugging.

## How to test
Deploy to CODE and add a malformed XML file  to the [crossword-files-for-processing-code](https://s3.console.aws.amazon.com/s3/buckets/crossword-files-for-processing-code?region=eu-west-1) bucket (there are plenty of malformed XML files in the PROD processing bucket to choose from). The uploader lambda should be triggered when a new file is detected and all the malformed XML files in the processing bucket should appear in the failed bucket