### PR TITLE
Have the uploaders also archive files that are not xml and not pdf

### DIFF
--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/Lambda.scala
@@ -22,6 +22,14 @@ class Lambda
     }
 
     println("The uploading of crossword xml files has finished.")
-  }
 
+    println("Archiving non-crossword files...")
+
+    for (nonCrosswordFileKey <- getNotCrosswordFileKeys(config)) {
+      println(s"Archiving $nonCrosswordFileKey")
+      archiveFailedCrosswordXMLFile(config, nonCrosswordFileKey)
+    }
+
+    println("Archiving complete")
+  }
 }

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/crosswords/CrosswordStore.scala
@@ -12,6 +12,16 @@ import com.gu.crossword.services.S3.s3Client
 
 trait CrosswordStore {
 
+  def getNotCrosswordFileKeys(config: Config): List[String] = {
+    s3Client
+      .listObjects(config.crosswordsBucketName)
+      .getObjectSummaries
+      .asScala
+      .toList
+      .map(_.getKey)
+      .filterNot(key => key.endsWith(".xml") || key.endsWith(".pdf"))
+  }
+
   def getCrosswordXmlFiles(config: Config): List[CrosswordXmlFile] = {
     s3Client
       .listObjects(config.crosswordsBucketName)


### PR DESCRIPTION
Because they will never get uploaded by either.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

#31 was fantastic - it cleared up a bunch of xml and pdfs that had lingered in the bucket in an unprocessable state. However there's still a whole bunch of files in there which aren't targets for either uploader (ie. don't have xml or pdf extensions) so aren't targeted for archival. This PR adds an extra step to the XML lambda, which will detect any objects without an xml or pdf extension and archive those as part of a cleanup.

