### PR TITLE
Add dual running for crossword-pdf-uploader to crosswordv2 service

### DIFF
--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
@@ -83,11 +83,6 @@ trait CrosswordPdfUploaderLambda
       throw new Exception(s"Failures detected when uploading crossword PDF files (${failedKeys})!")
     }
 
-    successes.foreach { key =>
-      println(s"Successfully uploaded crossword PDF: ${key}")
-      archiveProcessedPdfFiles(config.crosswordsBucketName, key)
-    }
-
     println("The uploading of crossword PDF files has finished.")
   }
 }

--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import com.gu.crossword.pdfuploader.models.CrosswordPdfFile
 import com.gu.crossword.pdfuploader.{CrosswordConfigRetriever, CrosswordPdfStore, CrosswordPdfUploader, HttpCrosswordPdfUploader, PublicPdfStore, S3CrosswordConfigRetriever, S3CrosswordPdfStore, S3PublicPdfStore}
 
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 trait CrosswordPdfUploaderLambda
   extends RequestHandler[JMap[String, Object], Unit]
@@ -27,6 +27,23 @@ trait CrosswordPdfUploaderLambda
     }
   }
 
+  private def doV2Upload(uploadV2Url: String, pdfFile: CrosswordPdfFile, fileLocation: String): Unit = Try {
+    val uploadLocation = s"${fileLocation}/${pdfFile.awsKey}"
+    val v2Result = for {
+      _ <- uploadPdfCrosswordLocation(uploadV2Url, pdfFile, uploadLocation)
+    } yield ()
+
+    v2Result match {
+      case Success(_) =>
+        println(s"Successfully dual uploaded crossword PDF ${pdfFile.awsKey} to crosswordv2")
+      case Failure(error) =>
+        println(
+          s"Failed to dual upload crossword PDF ${pdfFile.awsKey} to crosswordv2 with error: ${error.getMessage}"
+        )
+        error.getStackTrace.foreach(println)
+    }
+  }
+
   def handleRequest(event: JMap[String, Object], context: Context): Unit = {
     val config = getConfig(context)
 
@@ -41,7 +58,7 @@ trait CrosswordPdfUploaderLambda
         uploadUrl = config.crosswordMicroAppUrl,
         pdfFile = pdfFile
       )
-    } partitionMap(identity)
+    } partitionMap (identity)
 
     failures.foreach {
       case (key, e) =>
@@ -56,6 +73,9 @@ trait CrosswordPdfUploaderLambda
     }
 
     println(s"The uploading of crossword PDF files has finished, ${successes.size} succeeded, ${failures.size} failed.}")
+
+    // Dual upload to crosswordv2 service
+    crosswordPdfFiles.map(doV2Upload(config.crosswordV2Url, _, config.crosswordPdfPublicFileLocation))
 
     // We want to fail the lambda if any of the uploads failed
     if (failures.size > 0) {

--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
@@ -62,6 +62,13 @@ trait CrosswordPdfUploaderLambda
       val failedKeys = failures.map(_._1).mkString(", ")
       throw new Exception(s"Failures detected when uploading crossword PDF files (${failedKeys})!")
     }
+
+    successes.foreach { key =>
+      println(s"Successfully uploaded crossword PDF: ${key}")
+      archiveProcessedPdfFiles(config.crosswordsBucketName, key)
+    }
+
+    println("The uploading of crossword PDF files has finished.")
   }
 }
 

--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
@@ -75,7 +75,9 @@ trait CrosswordPdfUploaderLambda
     println(s"The uploading of crossword PDF files has finished, ${successes.size} succeeded, ${failures.size} failed.}")
 
     // Dual upload to crosswordv2 service
-    crosswordPdfFiles.map(doV2Upload(config.crosswordV2Url, _, config.crosswordPdfPublicFileLocation))
+    config.crosswordV2Url.map(url =>
+      crosswordPdfFiles.map(doV2Upload(url, _, config.crosswordPdfPublicFileLocation))
+    )
 
     // We want to fail the lambda if any of the uploads failed
     if (failures.size > 0) {

--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/pdfuploader/CrosswordConfigRetriever.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/pdfuploader/CrosswordConfigRetriever.scala
@@ -22,7 +22,7 @@ trait S3CrosswordConfigRetriever extends CrosswordConfigRetriever {
     val crosswordMicroAppUrl = Option(config.getProperty("crosswordmicroapp.url")) getOrElse sys.error("'crosswordmicroapp.url' property missing.")
 
     // Fail safe in case crosswordV2Url is not set
-    val crosswordV2Url = Option(config.getProperty("crosswordv2.url")) getOrElse "https://crossword-v2-url"
+    val crosswordV2Url = Option(config.getProperty("crosswordv2.url"))
 
     val crosswordPdfPublicBucketName = s"crosswords-pdf-public-${stage.toLowerCase}"
     val crosswordPdfPublicFileLocation = if (isProd) s"https://crosswords-static.guim.co.uk" else s"https://s3-eu-west-1.amazonaws.com/$crosswordPdfPublicBucketName"

--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/pdfuploader/CrosswordConfigRetriever.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/pdfuploader/CrosswordConfigRetriever.scala
@@ -20,6 +20,10 @@ trait S3CrosswordConfigRetriever extends CrosswordConfigRetriever {
     val config = loadConfig(stage)
 
     val crosswordMicroAppUrl = Option(config.getProperty("crosswordmicroapp.url")) getOrElse sys.error("'crosswordmicroapp.url' property missing.")
+
+    // Fail safe in case crosswordV2Url is not set
+    val crosswordV2Url = Option(config.getProperty("crosswordv2.url")) getOrElse "https://crossword-v2-url"
+
     val crosswordPdfPublicBucketName = s"crosswords-pdf-public-${stage.toLowerCase}"
     val crosswordPdfPublicFileLocation = if (isProd) s"https://crosswords-static.guim.co.uk" else s"https://s3-eu-west-1.amazonaws.com/$crosswordPdfPublicBucketName"
 
@@ -31,6 +35,7 @@ trait S3CrosswordConfigRetriever extends CrosswordConfigRetriever {
 
     CrosswordPdfLambdaConfig(
       crosswordMicroAppUrl,
+      crosswordV2Url,
       crosswordsBucketName,
       crosswordPdfPublicBucketName,
       crosswordPdfPublicFileLocation

--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/pdfuploader/models/CrosswordPdfLambdaConfig.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/pdfuploader/models/CrosswordPdfLambdaConfig.scala
@@ -2,7 +2,7 @@ package com.gu.crossword.pdfuploader.models
 
 case class CrosswordPdfLambdaConfig(
   crosswordMicroAppUrl: String,
-  crosswordV2Url: String,
+  crosswordV2Url: Option[String],
   crosswordsBucketName: String,
   crosswordPdfPublicBucketName: String,
   crosswordPdfPublicFileLocation: String,

--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/pdfuploader/models/CrosswordPdfLambdaConfig.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/pdfuploader/models/CrosswordPdfLambdaConfig.scala
@@ -2,6 +2,7 @@ package com.gu.crossword.pdfuploader.models
 
 case class CrosswordPdfLambdaConfig(
   crosswordMicroAppUrl: String,
+  crosswordV2Url: String,
   crosswordsBucketName: String,
   crosswordPdfPublicBucketName: String,
   crosswordPdfPublicFileLocation: String,

--- a/crossword-pdf-uploader/src/test/scala/com/gu/crossword/LambdaTest.scala
+++ b/crossword-pdf-uploader/src/test/scala/com/gu/crossword/LambdaTest.scala
@@ -12,7 +12,6 @@ import scala.util.{Failure, Success, Try}
 import scala.xml.Elem
 
 
-
 class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
 
   type PageCreator = (String, Elem) => Try[Unit]
@@ -44,7 +43,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
         crosswordPdfPublicBucketName = "crossword-pdf-public-bucket-name",
         crosswordPdfPublicFileLocation = "crossword-pdf-public-file-location",
         crosswordMicroAppUrl = "https://crossword-microapp-url",
-        crosswordV2Url = "https://crossword-v2-url",
+        crosswordV2Url = None,
         crosswordsBucketName = "crosswords-bucket-name",
       )
 
@@ -74,8 +73,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
     fakeLambda.handleRequest(null, null)
 
     // Check location is constructed as expected
-    // TODO: This makes 2 calls when dual-running, when we have migrated to v2 we should only make 1 call
-    uploadCrosswordLocationCalled.size should be(2)
+    uploadCrosswordLocationCalled.size should be(1)
     uploadCrosswordLocationCalled map {
       case (_, location, _) =>
         location should be("crossword-pdf-public-file-location/gdn.cryptic.20230418.pdf")
@@ -140,7 +138,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
         crosswordPdfPublicBucketName = "crossword-pdf-public-bucket-name",
         crosswordPdfPublicFileLocation = "crossword-pdf-public-file-location",
         crosswordMicroAppUrl = baseUrl,
-        crosswordV2Url = "https://crossword-v2-url",
+        crosswordV2Url = Some("https://crossword-v2-url"),
         crosswordsBucketName = "crosswords-bucket-name",
       )
     }

--- a/crossword-pdf-uploader/src/test/scala/com/gu/crossword/LambdaTest.scala
+++ b/crossword-pdf-uploader/src/test/scala/com/gu/crossword/LambdaTest.scala
@@ -1,7 +1,9 @@
 package com.gu.crossword
 
 import com.amazonaws.services.lambda.runtime.Context
+import com.gu.crossword.pdfuploader.HttpCrosswordPdfUploader
 import com.gu.crossword.pdfuploader.models.{CrosswordPdfFile, CrosswordPdfFileName, CrosswordPdfLambdaConfig}
+import okhttp3.mockwebserver.{MockResponse, MockWebServer}
 import org.scalatest.TryValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -42,6 +44,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
         crosswordPdfPublicBucketName = "crossword-pdf-public-bucket-name",
         crosswordPdfPublicFileLocation = "crossword-pdf-public-file-location",
         crosswordMicroAppUrl = "https://crossword-microapp-url",
+        crosswordV2Url = "https://crossword-v2-url",
         crosswordsBucketName = "crosswords-bucket-name",
       )
 
@@ -71,8 +74,9 @@ class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
     fakeLambda.handleRequest(null, null)
 
     // Check location is constructed as expected
-    uploadCrosswordLocationCalled.size should be(1)
-    uploadCrosswordLocationCalled.head match {
+    // TODO: This makes 2 calls when dual-running, when we have migrated to v2 we should only make 1 call
+    uploadCrosswordLocationCalled.size should be(2)
+    uploadCrosswordLocationCalled map {
       case (_, location, _) =>
         location should be("crossword-pdf-public-file-location/gdn.cryptic.20230418.pdf")
     }
@@ -115,5 +119,37 @@ class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
 
     fakeLambda.archiveCalled should be(0)
     fakeLambda.archiveFailedCalled should be(1)
+  }
+
+  it should "not fail if the v2 endpoint fails" in {
+    val expectedResponse = "<response />"
+    val mockHttpServer = new MockWebServer()
+    mockHttpServer.start()
+
+    val baseUrl = mockHttpServer.url("/pdf").toString
+    mockHttpServer.enqueue(new MockResponse().setBody(expectedResponse));
+
+    val fileName = "gdn.cryptic.20230418.pdf"
+    val crosswordPdfFile = CrosswordPdfFileName(fileName).get
+
+    val fakeLambda = new FakeLambda with HttpCrosswordPdfUploader {
+      override def getCrosswordPdfFiles(bucketName: String): List[CrosswordPdfFile] = List(CrosswordPdfFile(fileName, crosswordPdfFile, Array.empty))
+      override def uploadPdfCrosswordFile(bucketName: String, fileLocation: String, crosswordPdfFile: CrosswordPdfFile): Try[Unit] =  Success(())
+
+      override def getConfig(context: Context): CrosswordPdfLambdaConfig = CrosswordPdfLambdaConfig(
+        crosswordPdfPublicBucketName = "crossword-pdf-public-bucket-name",
+        crosswordPdfPublicFileLocation = "crossword-pdf-public-file-location",
+        crosswordMicroAppUrl = baseUrl,
+        crosswordV2Url = "https://crossword-v2-url",
+        crosswordsBucketName = "crosswords-bucket-name",
+      )
+    }
+
+    fakeLambda.handleRequest(null, null)
+
+    fakeLambda.archiveCalled should be(1)
+    fakeLambda.archiveFailedCalled should be(0)
+
+    mockHttpServer.shutdown()
   }
 }

--- a/crossword-pdf-uploader/src/test/scala/com/gu/crossword/LambdaTest.scala
+++ b/crossword-pdf-uploader/src/test/scala/com/gu/crossword/LambdaTest.scala
@@ -10,6 +10,7 @@ import scala.util.{Failure, Success, Try}
 import scala.xml.Elem
 
 
+
 class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
 
   type PageCreator = (String, Elem) => Try[Unit]

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/Lambda.scala
@@ -91,19 +91,9 @@ trait CrosswordXmlUploaderLambda
 }
 
 class Lambda
-<<<<<<< HEAD
-  extends CrosswordXmlUploaderLambda
-    with KinesisComposerOps
-    with S3CrosswordStore
-    with CrosswordXmlUploader
-    with HttpCrosswordClientOps
-    with S3CrosswordConfigRetriever
-
-=======
     extends CrosswordXmlUploaderLambda
       with KinesisComposerOps
       with S3CrosswordStore
       with CrosswordXmlUploader
       with HttpCrosswordClientOps
       with S3CrosswordConfigRetriever
->>>>>>> fcb63f7 (Update pdf uploader)

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/Lambda.scala
@@ -91,6 +91,7 @@ trait CrosswordXmlUploaderLambda
 }
 
 class Lambda
+<<<<<<< HEAD
   extends CrosswordXmlUploaderLambda
     with KinesisComposerOps
     with S3CrosswordStore
@@ -98,3 +99,11 @@ class Lambda
     with HttpCrosswordClientOps
     with S3CrosswordConfigRetriever
 
+=======
+    extends CrosswordXmlUploaderLambda
+      with KinesisComposerOps
+      with S3CrosswordStore
+      with CrosswordXmlUploader
+      with HttpCrosswordClientOps
+      with S3CrosswordConfigRetriever
+>>>>>>> fcb63f7 (Update pdf uploader)


### PR DESCRIPTION
## What does this change?

Follow https://github.com/guardian/crossword-uploader/pull/35. This change notifies the [new `crosswordv2` service](https://github.com/guardian/crosswordv2) about crosswords as well as continuing to notify the existing current service. Requests to `crosswordsv2` should fail safely in a way that does not prevent the existing service from continuing to behave as expected.

## How to test

- [x] Run the tests
- [x] Run this locally using CODE configuration with an uploaded PDF
- [ ] Deploy this to CODE and test it behaves as expected with an uploaded PDF

## How can we measure success?

Both crosswords services can run at the same time without impacting one another allowing us quick feedback on the running of the crosswordv2 service.

## Have we considered potential risks?

This change has the potential to impact the existing crossword service if contacting the V2 endpoint causes the V1 request to fail, we've attempted to mitigate this with thorough testing and wrapping function calls in `Try` where appropriate. 