### PR TITLE
Close response to avoid warning

### DIFF
--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/pdfuploader/CrosswordPdfUploader.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/pdfuploader/CrosswordPdfUploader.scala
@@ -26,6 +26,7 @@ trait HttpCrosswordPdfUploader extends CrosswordPdfUploader {
     val request = new Request.Builder().url(url).post(requestBody).build()
 
     val response = httpClient.newCall(request).execute()
+    response.close()
 
     // Fail if the crossword microapp returns a 404, as this means the crossword XML file has not been uploaded yet.
     if (response.code() == HttpStatus.SC_NOT_FOUND) {


### PR DESCRIPTION
## What does this change?

The PDF uploader currently reports errors of the type:

```
WARNING: A connection to ... was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
```

This is because we are not closing the response, we address that here. This should not cause issues currently as the low volume and lambda environment mean that leaking the connection should not be an issue, in any case we should remove the error log.

## How to test

- [ ] Deploy to CODE, ensure this message is not visible.

## How can we measure success?

Cleaner logs.