### PR TITLE
[DO NOT MERGE] Switches the old microapp service for the migrated crosswordv2 service

### DIFF
--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/pdfuploader/CrosswordConfigRetriever.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/pdfuploader/CrosswordConfigRetriever.scala
@@ -19,10 +19,10 @@ trait S3CrosswordConfigRetriever extends CrosswordConfigRetriever {
     val stage = if (isProd) "PROD" else "CODE"
     val config = loadConfig(stage)
 
-    val crosswordMicroAppUrl = Option(config.getProperty("crosswordmicroapp.url")) getOrElse sys.error("'crosswordmicroapp.url' property missing.")
+    val crosswordMicroAppUrl = Option(config.getProperty("crosswordmicroapp.url"))
 
     // Fail safe in case crosswordV2Url is not set
-    val crosswordV2Url = Option(config.getProperty("crosswordv2.url"))
+    val crosswordV2Url = Option(config.getProperty("crosswordv2.url")) getOrElse sys.error("'crosswordv2.url' property missing.")
 
     val crosswordPdfPublicBucketName = s"crosswords-pdf-public-${stage.toLowerCase}"
     val crosswordPdfPublicFileLocation = if (isProd) s"https://crosswords-static.guim.co.uk" else s"https://s3-eu-west-1.amazonaws.com/$crosswordPdfPublicBucketName"

--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/pdfuploader/models/CrosswordPdfLambdaConfig.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/pdfuploader/models/CrosswordPdfLambdaConfig.scala
@@ -1,8 +1,8 @@
 package com.gu.crossword.pdfuploader.models
 
 case class CrosswordPdfLambdaConfig(
-  crosswordMicroAppUrl: String,
-  crosswordV2Url: Option[String],
+  crosswordMicroAppUrl: Option[String],
+  crosswordV2Url: String,
   crosswordsBucketName: String,
   crosswordPdfPublicBucketName: String,
   crosswordPdfPublicFileLocation: String,

--- a/crossword-pdf-uploader/src/test/scala/com/gu/crossword/LambdaTest.scala
+++ b/crossword-pdf-uploader/src/test/scala/com/gu/crossword/LambdaTest.scala
@@ -42,8 +42,8 @@ class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
       override def getConfig(context: Context): CrosswordPdfLambdaConfig = CrosswordPdfLambdaConfig(
         crosswordPdfPublicBucketName = "crossword-pdf-public-bucket-name",
         crosswordPdfPublicFileLocation = "crossword-pdf-public-file-location",
-        crosswordMicroAppUrl = "https://crossword-microapp-url",
-        crosswordV2Url = None,
+        crosswordMicroAppUrl = None,
+        crosswordV2Url = "https://crossword-microapp-url",
         crosswordsBucketName = "crosswords-bucket-name",
       )
 
@@ -119,7 +119,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
     fakeLambda.archiveFailedCalled should be(1)
   }
 
-  it should "not fail if the v2 endpoint fails" in {
+  it should "not fail if the old crossword service endpoint fails" in {
     val expectedResponse = "<response />"
     val mockHttpServer = new MockWebServer()
     mockHttpServer.start()
@@ -137,8 +137,8 @@ class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
       override def getConfig(context: Context): CrosswordPdfLambdaConfig = CrosswordPdfLambdaConfig(
         crosswordPdfPublicBucketName = "crossword-pdf-public-bucket-name",
         crosswordPdfPublicFileLocation = "crossword-pdf-public-file-location",
-        crosswordMicroAppUrl = baseUrl,
-        crosswordV2Url = Some("https://crossword-v2-url"),
+        crosswordMicroAppUrl = Some("https://crossword-microapp-url"),
+        crosswordV2Url = baseUrl,
         crosswordsBucketName = "crosswords-bucket-name",
       )
     }

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/xmluploader/CrosswordConfigRetriever.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/xmluploader/CrosswordConfigRetriever.scala
@@ -17,8 +17,8 @@ trait S3CrosswordConfigRetriever extends CrosswordConfigRetriever {
     val stage = if (isProd) "PROD" else "CODE"
     val config = loadConfig(stage)
 
-    val crosswordMicroAppUrl = Option(config.getProperty("crosswordmicroapp.url")) getOrElse sys.error("'crosswordmicroapp.url' property missing.")
-    val crosswordV2Url = Option(config.getProperty("crosswordv2.url"))
+    val crosswordMicroAppUrl = Option(config.getProperty("crosswordmicroapp.url"))
+    val crosswordV2Url = Option(config.getProperty("crosswordv2.url")) getOrElse sys.error("'crosswordv2.url' property missing.")
 
     val composerCrosswordIntegrationStreamName = Option(
       config.getProperty("composerCrosswordIntegration.streamName")).getOrElse(

--- a/crossword-xml-uploader/src/main/scala/com/gu/crossword/xmluploader/models/CrosswordXmlLambdaConfig.scala
+++ b/crossword-xml-uploader/src/main/scala/com/gu/crossword/xmluploader/models/CrosswordXmlLambdaConfig.scala
@@ -1,8 +1,8 @@
 package com.gu.crossword.xmluploader.models
 
 case class CrosswordXmlLambdaConfig(
-                                  crosswordMicroAppUrl: String,
-                                  crosswordV2Url: Option[String],
+                                  crosswordMicroAppUrl: Option[String],
+                                  crosswordV2Url: String,
                                   composerCrosswordIntegrationStreamName: String,
                                   crosswordsBucketName: String
                                 )

--- a/crossword-xml-uploader/src/test/scala/com/gu/crossword/LambdaTest.scala
+++ b/crossword-xml-uploader/src/test/scala/com/gu/crossword/LambdaTest.scala
@@ -45,8 +45,8 @@ class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
 
       override def getConfig(context: Context): CrosswordXmlLambdaConfig = CrosswordXmlLambdaConfig(
         crosswordsBucketName = "crosswords-bucket",
-        crosswordMicroAppUrl = "https://crossword-microapp-url",
-        crosswordV2Url = None,
+        crosswordMicroAppUrl = None,
+        crosswordV2Url = "https://crossword-microapp-url",
         composerCrosswordIntegrationStreamName = "crossword-integration-stream-name",
       )
     }
@@ -125,7 +125,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
     fakeLambda.archiveFailedCalled should be(1)
   }
 
-  it should "not fail if the v2 endpoint fails" in {
+  it should "not fail if the old crossword service endpoint fails" in {
     val crosswordMicroAppResponse = Source.fromResource("example-crossword-microapp-response-quiptic-834.xml").getLines().mkString
     val crosswordMicroAppResponseXml = XML.loadString(crosswordMicroAppResponse)
 
@@ -145,8 +145,8 @@ class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
 
       override def getConfig(context: Context): CrosswordXmlLambdaConfig = CrosswordXmlLambdaConfig(
         crosswordsBucketName = "crosswords-bucket",
-        crosswordMicroAppUrl = baseUrl,
-        crosswordV2Url = Some("https://crossword-v2-url"),
+        crosswordMicroAppUrl = Some("https://crossword-microapp-url"),
+        crosswordV2Url = baseUrl,
         composerCrosswordIntegrationStreamName = "crossword-integration-stream-name",
       )
     }


### PR DESCRIPTION
## What does this change?

This change now treats the V2 service as the critical upload instead of the micrapp while still dual running and continuing to write to the old app to keep it in sync in the case we'd need to switch back.

> **Warning**
> Do **NOT** merge this until we are ready to switch-over!

## How to test

- [ ] Run the tests
- [ ] Deploy this to the CODE environment, observe it behaves as expected.

## How can we measure success?

Successful switch-over to the new service while continuing to keep the old database is sync in case it's required.