### PR TITLE
Remove dual uploading pdf to old app and new app

### DIFF
--- a/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
+++ b/crossword-pdf-uploader/src/main/scala/com/gu/crossword/Lambda.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import com.gu.crossword.pdfuploader.models.CrosswordPdfFile
 import com.gu.crossword.pdfuploader.{CrosswordConfigRetriever, CrosswordPdfStore, CrosswordPdfUploader, HttpCrosswordPdfUploader, PublicPdfStore, S3CrosswordConfigRetriever, S3CrosswordPdfStore, S3PublicPdfStore}
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{Failure, Success}
 
 trait CrosswordPdfUploaderLambda
   extends RequestHandler[JMap[String, Object], Unit]
@@ -24,26 +24,6 @@ trait CrosswordPdfUploaderLambda
     uploadResult match {
       case Success(_) => Right(pdfFile.awsKey)
       case Failure(error) => Left((pdfFile.awsKey, error))
-    }
-  }
-
-  // Upload to old crossword service - do NOT createPage
-  // This should be removed once the crosswordv2 service has been running for a while
-  // Wrapping with Try as we must fail safe and not stop the lambda from running if this fails
-  private def doV1Upload(url: String, pdfFile: CrosswordPdfFile, fileLocation: String): Unit = Try {
-    val uploadLocation = s"${fileLocation}/${pdfFile.awsKey}"
-    val result = for {
-      _ <- uploadPdfCrosswordLocation(url, pdfFile, uploadLocation)
-    } yield ()
-
-    result match {
-      case Success(_) =>
-        println(s"Successfully dual uploaded crossword PDF ${pdfFile.awsKey} to old crossword service")
-      case Failure(error) =>
-        println(
-          s"Failed to dual upload crossword PDF ${pdfFile.awsKey} to old crossword service with error: ${error.getMessage}"
-        )
-        error.getStackTrace.foreach(println)
     }
   }
 
@@ -77,13 +57,8 @@ trait CrosswordPdfUploaderLambda
 
     println(s"The uploading of crossword PDF files has finished, ${successes.size} succeeded, ${failures.size} failed.}")
 
-    // Dual upload to old crossword service
-    config.crosswordMicroAppUrl.map(url =>
-      crosswordPdfFiles.map(doV1Upload(url, _, config.crosswordPdfPublicFileLocation))
-    )
-
     // We want to fail the lambda if any of the uploads failed
-    if (failures.size > 0) {
+    if (failures.nonEmpty) {
       val failedKeys = failures.map(_._1).mkString(", ")
       throw new Exception(s"Failures detected when uploading crossword PDF files (${failedKeys})!")
     }

--- a/crossword-pdf-uploader/src/test/scala/com/gu/crossword/LambdaTest.scala
+++ b/crossword-pdf-uploader/src/test/scala/com/gu/crossword/LambdaTest.scala
@@ -1,9 +1,7 @@
 package com.gu.crossword
 
 import com.amazonaws.services.lambda.runtime.Context
-import com.gu.crossword.pdfuploader.HttpCrosswordPdfUploader
 import com.gu.crossword.pdfuploader.models.{CrosswordPdfFile, CrosswordPdfFileName, CrosswordPdfLambdaConfig}
-import okhttp3.mockwebserver.{MockResponse, MockWebServer}
 import org.scalatest.TryValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -101,7 +99,7 @@ class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
     fakeLambda.archiveFailedCalled should be(1)
   }
 
-  it should "archive as failure a processed crossword if uploading toa public bucket fails" in {
+  it should "archive as failure a processed crossword if uploading to a public bucket fails" in {
     val fileName = "gdn.cryptic.20230418.pdf"
     val crosswordPdfFile = CrosswordPdfFileName(fileName).get
 
@@ -117,37 +115,5 @@ class LambdaTest extends AnyFlatSpec with Matchers with TryValues {
 
     fakeLambda.archiveCalled should be(0)
     fakeLambda.archiveFailedCalled should be(1)
-  }
-
-  it should "not fail if the old crossword service endpoint fails" in {
-    val expectedResponse = "<response />"
-    val mockHttpServer = new MockWebServer()
-    mockHttpServer.start()
-
-    val baseUrl = mockHttpServer.url("/pdf").toString
-    mockHttpServer.enqueue(new MockResponse().setBody(expectedResponse));
-
-    val fileName = "gdn.cryptic.20230418.pdf"
-    val crosswordPdfFile = CrosswordPdfFileName(fileName).get
-
-    val fakeLambda = new FakeLambda with HttpCrosswordPdfUploader {
-      override def getCrosswordPdfFiles(bucketName: String): List[CrosswordPdfFile] = List(CrosswordPdfFile(fileName, crosswordPdfFile, Array.empty))
-      override def uploadPdfCrosswordFile(bucketName: String, fileLocation: String, crosswordPdfFile: CrosswordPdfFile): Try[Unit] =  Success(())
-
-      override def getConfig(context: Context): CrosswordPdfLambdaConfig = CrosswordPdfLambdaConfig(
-        crosswordPdfPublicBucketName = "crossword-pdf-public-bucket-name",
-        crosswordPdfPublicFileLocation = "crossword-pdf-public-file-location",
-        crosswordMicroAppUrl = Some("https://crossword-microapp-url"),
-        crosswordV2Url = baseUrl,
-        crosswordsBucketName = "crosswords-bucket-name",
-      )
-    }
-
-    fakeLambda.handleRequest(null, null)
-
-    fakeLambda.archiveCalled should be(1)
-    fakeLambda.archiveFailedCalled should be(0)
-
-    mockHttpServer.shutdown()
   }
 }


### PR DESCRIPTION
## What does this change?

In anticipation of decommisioning the old crossword app, stop trying to keep it in sync with the crosswordv2.

Follows https://github.com/guardian/crossword-uploader/pull/39, which remove the dual xml upload.

## How to test

- [x] Run this in CODE, check it still pushes to crosswordv2

## How can we measure success?

Less code is more better.