### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+**DEPRECATED: This project has been replaced by the crosswordv2 project.**
+
+_See [guardian/crosswordv2](https://github.com/guardian/crosswordv2/pull/163) for more information._
+
 # Crossword Uploader Lambdas
 Lambdas used to move crosswords from a bucket in s3 into flexible content. They are managed
 by the Editorial Tools team.


### PR DESCRIPTION
## What does this change?

This project is now deprecated in favour of the crosswordv2 project, this adds a deprecation notice.

See: https://github.com/guardian/crosswordv2/pull/163

> [!IMPORTANT]  
> This repository should be archived after merge.